### PR TITLE
Feature/ng 1442

### DIFF
--- a/jqqb/__init__.py
+++ b/jqqb/__init__.py
@@ -30,6 +30,7 @@ class QueryBuilder:
             {
                 "object": object,
                 "predicate": self.rule_group.get_predicate(object=object),
+                "results": self.rule_group.inspect(object=object),
                 "rules": self.rule_group.jsonify(object=object),
                 "selected": self.object_matches_rules(object=object),
             } for object in objects

--- a/jqqb/__init__.py
+++ b/jqqb/__init__.py
@@ -29,8 +29,8 @@ class QueryBuilder:
         return [
             {
                 "object": object,
-                "rules": self.rule_group.jsonify(),
                 "predicate": self.rule_group.get_predicate(object=object),
+                "rules": self.rule_group.jsonify(object=object),
                 "selected": self.object_matches_rules(object=object),
             } for object in objects
         ]

--- a/jqqb/input.py
+++ b/jqqb/input.py
@@ -39,7 +39,6 @@ class Input:
         self.field = field
         self.type = type
         self.value = value
-        self._json = None
 
     @classmethod
     def create_input_from_json(cls, input_json: Union[dict, str]) -> "Input":
@@ -61,15 +60,13 @@ class Input:
             else input_json
         )
         field = parsed_input_json["field"]
-        instance = cls(
+        return cls(
             field=field,
             type=parsed_input_json["type"],
             value=(
                 cls.NotRetrievedValue if field else parsed_input_json["value"]
             ),
         )
-        instance._json = parsed_input_json
-        return instance
 
     def get_value(self, object: Optional[dict] = None) -> Any:
         if self.value is self.NotRetrievedValue and object is not None:
@@ -82,10 +79,12 @@ class Input:
         last_object = reduce(lambda x, y: x.get(y, {}), fields[:-1], object)
         return last_object.get(fields[-1], self.MissingKey)
 
-    def jsonify(self) -> dict:
+    def jsonify(self, object: dict) -> dict:
         return {
-            "field": self.field, "type": self.type, "value": self.value
-        } if self._json is None else self._json
+            "field": self.field,
+            "type": self.type,
+            "value": self.get_value(object=object),
+        }
 
     def typecast_value(self, value_to_cast: Any) -> Any:
         cast_function = self._CAST_FUNCTIONS.get(self.type)

--- a/jqqb/input.py
+++ b/jqqb/input.py
@@ -1,6 +1,5 @@
 import json
 from datetime import date, datetime, time
-from distutils.util import strtobool
 from functools import reduce
 from typing import Any, Optional, Union
 
@@ -13,20 +12,18 @@ class Input:
         pass
 
     _CAST_FUNCTIONS = {
-        "string": str,
-        "integer": int,
-        "double": float,
+        "boolean": bool,
         "datetime": lambda x: (
             datetime.fromisoformat(x) if isinstance(x, str) else x
         ),
         "date": lambda x: (
             date.fromisoformat(x) if isinstance(x, str) else x
         ),
+        "double": float,
+        "integer": int,
+        "string": str,
         "time": lambda x: (
             time.fromisoformat(x) if isinstance(x, str) else x
-        ),
-        "boolean": lambda x: (
-            strtobool(x) if isinstance(x, str) else x
         ),
     }
 

--- a/jqqb/input.py
+++ b/jqqb/input.py
@@ -57,13 +57,12 @@ class Input:
             else input_json
         )
         field = parsed_input_json["field"]
-        return cls(
-            field=field,
-            type=parsed_input_json["type"],
-            value=(
-                cls.NotRetrievedValue if field else parsed_input_json["value"]
-            ),
-        )
+        data = {"field": field, "type": parsed_input_json["type"]}
+
+        if not field:
+            data["value"] = parsed_input_json["value"]
+
+        return cls(**data)
 
     def get_value(self, object: Optional[dict] = None) -> Any:
         if self.value is self.NotRetrievedValue and object is not None:

--- a/jqqb/operator.py
+++ b/jqqb/operator.py
@@ -7,9 +7,14 @@ class Operator:
         return getattr(Operator, f"eval_{operator_name}")
 
     @staticmethod
-    def get_operator_predicate(operator: callable) -> str:
+    def jsonify(operator: callable) -> str:
         """Inverse method of get_operator."""
         return operator.__name__[5:]
+
+    @staticmethod
+    def get_operator_predicate(operator: callable) -> str:
+        """Deprecated: Use `jsonify`"""
+        return Operator.jsonify(operator=operator)
 
     @staticmethod
     def eval_begins_with(left, right):

--- a/jqqb/rule.py
+++ b/jqqb/rule.py
@@ -58,3 +58,9 @@ class Rule:
             f"{Operator.get_operator_predicate(operator=self.operator)}("
             f"{', '.join(input_predicates)})"
         )
+
+    def jsonify(self, object: dict) -> dict:
+        return {
+            "inputs": [input.jsonify(object=object) for input in self.inputs],
+            "operator": Operator.jsonify(operator=self.operator),
+        }

--- a/jqqb/rule.py
+++ b/jqqb/rule.py
@@ -31,9 +31,7 @@ class Rule:
         return cls(
             operator=Operator.get_operator(parsed_rule_json["operator"]),
             inputs=[
-                Input.create_input_from_json(
-                    input_json=parsed_rule_input_json
-                )
+                Input.create_input_from_json(input_json=parsed_rule_input_json)
                 for parsed_rule_input_json
                 in parsed_rule_json["inputs"]
             ]
@@ -57,6 +55,12 @@ class Rule:
         return (
             f"{Operator.get_operator_predicate(operator=self.operator)}("
             f"{', '.join(input_predicates)})"
+        )
+
+    def inspect(self, object: dict) -> tuple:
+        return (
+            *[input.get_value(object=object) for input in self.inputs],
+            self.evaluate(object=object),
         )
 
     def jsonify(self, object: dict) -> dict:

--- a/jqqb/rule_group.py
+++ b/jqqb/rule_group.py
@@ -15,7 +15,6 @@ class RuleGroup:
         self.condition = condition
         self.condition_operation = self._CONDITIONS[condition]
         self.rules = rules
-        self._json = None
 
     @classmethod
     def create_rule_group_from_json(
@@ -37,7 +36,7 @@ class RuleGroup:
             if isinstance(rule_group_json, str)
             else rule_group_json
         )
-        instance = cls(
+        return cls(
             condition=parsed_rule_group_json["condition"],
             rules=[
                 cls.create_rule_group_from_json(
@@ -51,8 +50,6 @@ class RuleGroup:
                 in parsed_rule_group_json["rules"]
             ]
         )
-        instance._json = parsed_rule_group_json
-        return instance
 
     def evaluate(self, object: dict) -> bool:
         return self.condition_operation(
@@ -65,8 +62,8 @@ class RuleGroup:
         ]
         return f"{self.condition}({', '.join(rule_predicates)})"
 
-    def jsonify(self) -> dict:
+    def jsonify(self, object: dict) -> dict:
         return {
             "condition": self.condition,
-            "rules": [rule.jsonify() for rule in self.rules],
-        } if self._json is None else self._json
+            "rules": [rule.jsonify(object=object) for rule in self.rules],
+        }

--- a/jqqb/rule_group.py
+++ b/jqqb/rule_group.py
@@ -62,6 +62,12 @@ class RuleGroup:
         ]
         return f"{self.condition}({', '.join(rule_predicates)})"
 
+    def inspect(self, object: dict) -> list[tuple]:
+        return [
+            (rule.jsonify(object=object), rule.inspect(object=object))
+            for rule in self.rules
+        ]
+
     def jsonify(self, object: dict) -> dict:
         return {
             "condition": self.condition,

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,47 @@
+import unittest
+
+from jqqb.input import Input
+
+
+class TestInputFieldJsonify(unittest.TestCase):
+    def setUp(self) -> None:
+        self.object = {"dummy_key": "dummy_value"}
+        return super().setUp()
+
+    def test_input_field_jsonify(self):
+        instance = Input(field="dummy_key", type="str")
+        result = instance.jsonify(object=self.object)
+
+        expected_result = {
+            "field": "dummy_key", "value": "dummy_value", "type": "str"
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_input_value_jsonify(self):
+        instance = Input(field=None, type="str", value="dummy_value")
+        result = instance.jsonify(object=self.object)
+
+        expected_result = {
+            "field": None, "value": "dummy_value", "type": "str"
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_input_field_created_from_json_jsonify(self):
+        instance_json = {"field": "dummy_key", "value": None, "type": "str"}
+        instance = Input.create_input_from_json(input_json=instance_json)
+        result = instance.jsonify(object=self.object)
+
+        expected_result = {
+            "field": "dummy_key", "value": "dummy_value", "type": "str"
+        }
+        self.assertEqual(result, expected_result)
+
+    def test_input_value_created_from_json_jsonify(self):
+        instance_json = {"field": None, "value": "dummy_value", "type": "str"}
+        instance = Input.create_input_from_json(input_json=instance_json)
+        result = instance.jsonify(object=self.object)
+
+        expected_result = {
+            "field": None, "value": "dummy_value", "type": "str"
+        }
+        self.assertEqual(result, expected_result)

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from jqqb import QueryBuilder, RuleGroup
+from jqqb import QueryBuilder
 
 
 class TestCreateQueryBuilderInstance(unittest.TestCase):
@@ -74,7 +74,9 @@ class TestQueryBuilderInspect(unittest.TestCase):
         self.assertTrue(
             all(
                 key in result
-                for key in ("object", "predicate", "rules", "selected")
+                for key in (
+                    "object", "predicate", "results", "rules", "selected"
+                )
             )
         )
         self.assertEqual(result["object"], object)
@@ -83,6 +85,29 @@ class TestQueryBuilderInspect(unittest.TestCase):
         )
         self.assertIsInstance(result["rules"], dict)
         self.assertTrue(result["selected"])
+        self.assertEqual(
+            result["results"],
+            [
+                (
+                    {
+                        "operator": "equal",
+                        "inputs": [
+                            {
+                                "field": "dummy_key1",
+                                "value": "dummy_value",
+                                "type": "dummy_type1",
+                            },
+                            {
+                                "field": "dummy_key2",
+                                "value": "dummy_value",
+                                "type": "dummy_type2",
+                            }
+                        ],
+                    },
+                    ("dummy_value", "dummy_value", True),
+                ),
+            ]
+        )
 
         try:
             json.dumps(results)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,0 +1,43 @@
+import unittest
+
+from jqqb.input import Input
+from jqqb.operator import Operator
+from jqqb.rule import Rule
+
+
+class TestRuleJsonify(unittest.TestCase):
+    def setUp(self) -> None:
+        self.object = {"dummy_key": "dummy_value"}
+        self.expected_result = {
+            "operator": "equal",
+            "inputs": [
+                {"field": "dummy_key", "value": "dummy_value", "type": "str"},
+                {"field": None, "value": "dummy_value", "type": "str"},
+            ],
+        }
+        return super().setUp()
+
+    def test_rule_jsonify(self):
+        rule = Rule(
+            operator=Operator.eval_equal,
+            inputs=[
+                Input(type="str", field="dummy_key"),
+                Input(type="str", field=None, value="dummy_value"),
+            ],
+        )
+        result = rule.jsonify(object=self.object)
+
+        self.assertEqual(result, self.expected_result)
+
+    def test_rule_created_from_json_jsonify(self):
+        rule_json = {
+            "operator": "equal",
+            "inputs": [
+                {"field": "dummy_key", "value": None, "type": "str"},
+                {"field": None, "value": "dummy_value", "type": "str"},
+            ],
+        }
+        rule = Rule.create_rule_from_json(rule_json=rule_json)
+        result = rule.jsonify(object=self.object)
+
+        self.assertEqual(result, self.expected_result)

--- a/tests/test_rule_group.py
+++ b/tests/test_rule_group.py
@@ -1,0 +1,65 @@
+import unittest
+
+from jqqb.input import Input
+from jqqb.operator import Operator
+from jqqb.rule_group import RuleGroup
+from jqqb.rule import Rule
+
+
+class TestRuleGroupJsonify(unittest.TestCase):
+    def setUp(self) -> None:
+        self.object = {"dummy_key": "dummy_value"}
+        self.expected_result = {
+            "condition": "AND",
+            "rules": [{
+                "operator": "equal",
+                "inputs": [
+                    {
+                        "field": "dummy_key",
+                        "value": "dummy_value",
+                        "type": "str",
+                    },
+                    {
+                        "field": None,
+                        "value": "dummy_value",
+                        "type": "str",
+                    },
+                ],
+            }],
+        }
+        return super().setUp()
+
+    def test_rule_group_jsonify(self):
+        instance = RuleGroup(
+            condition="AND",
+            rules=[
+                Rule(
+                    operator=Operator.eval_equal,
+                    inputs=[
+                        Input(type="str", field="dummy_key"),
+                        Input(type="str", field=None, value="dummy_value"),
+                    ],
+                ),
+            ],
+        )
+        result = instance.jsonify(object=self.object)
+
+        self.assertEqual(result, self.expected_result)
+
+    def test_rule_group_created_from_json_jsonify(self):
+        instance_json = {
+            "condition": "AND",
+            "rules": [{
+                "operator": "equal",
+                "inputs": [
+                    {"field": "dummy_key", "value": None, "type": "str"},
+                    {"field": None, "value": "dummy_value", "type": "str"},
+                ],
+            }],
+        }
+        instance = RuleGroup.create_rule_group_from_json(
+            rule_group_json=instance_json
+        )
+        result = instance.jsonify(object=self.object)
+
+        self.assertEqual(result, self.expected_result)


### PR DESCRIPTION
Fix: Remove '_json' cache in jqqb objects
NG-1442: Get back 'results' field from QueryBuilder.inspect_objects for backward compatibility
Improvement: Remove useless 'isinstance(_, str)' chack for bool cast
Improvement: Don't manage Input.__init__ default value in other methods